### PR TITLE
add base64, base64url and hex encoding

### DIFF
--- a/packages/platform-node/src/Encoding.ts
+++ b/packages/platform-node/src/Encoding.ts
@@ -1,0 +1,109 @@
+/**
+ * This module provides encoding & decoding functionality for:
+ *
+ * - base64 (RFC4648)
+ * - base64 (URL)
+ * - hex
+ *
+ * @since 1.0.0
+ */
+import * as Either from "@effect/data/Either"
+import * as Base64 from "@effect/platform-node/internal/encoding/Base64"
+import * as Base64Url from "@effect/platform-node/internal/encoding/Base64Url"
+import * as Hex from "@effect/platform-node/internal/encoding/Hex"
+import { Base64DecodeError, Base64UrlDecodeError, HexDecodeError } from "@effect/platform/Encoding"
+
+export { Base64DecodeError, Base64UrlDecodeError, HexDecodeError } from "@effect/platform/Encoding"
+
+/**
+ * Encodes a Uint8Array into a base64 (RFC4648) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const encodeBase64 = Base64.encode
+
+/**
+ * Decodes a base64 (RFC4648) encoded string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const decodeBase64 = (str: string): Either.Either<Base64DecodeError, Uint8Array> => {
+  try {
+    return Either.right(Base64.decode(str))
+  } catch {
+    return Either.left(new Base64DecodeError())
+  }
+}
+
+/**
+ * Unsafely decodes a base64 (RFC4648) encoded string. Throws a type error if the
+ * given value isn't a valid base64 (RFC4648) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const unsafeDecodeBase64 = Base64.decode
+
+/**
+ * Encodes a Uint8Array into a base64 (URL) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const encodeBase64Url = Base64Url.encode
+
+/**
+ * Decodes a base64 (URL) encoded string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const decodeBase64Url = (str: string): Either.Either<Base64UrlDecodeError, Uint8Array> => {
+  try {
+    return Either.right(Base64Url.decode(str))
+  } catch {
+    return Either.left(new Base64UrlDecodeError())
+  }
+}
+
+/**
+ * Unsafely decodes a base64 (URL) encoded string. Throws a type error if the
+ * given value isn't a valid base64 (URL) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const unsafeDecodeBase64Url = Base64Url.decode
+
+/**
+ * Encodes a Uint8Array into a hex string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const encodeHex = Hex.encode
+
+/**
+ * Decodes a hex encoded string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const decodeHex = (str: string): Either.Either<HexDecodeError, Uint8Array> => {
+  try {
+    return Either.right(Hex.decode(str))
+  } catch {
+    return Either.left(new HexDecodeError())
+  }
+}
+
+/**
+ * Unsafely decodes a hex encoded string. Throws a type error if the
+ * given value isn't a valid hex string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const unsafeDecodeHex = Hex.decode

--- a/packages/platform-node/src/internal/encoding/Base64.ts
+++ b/packages/platform-node/src/internal/encoding/Base64.ts
@@ -1,0 +1,5 @@
+/** @internal */
+export const encode = (bytes: Uint8Array) => Buffer.from(bytes).toString("base64")
+
+/** @internal */
+export const decode = (str: string) => Uint8Array.from(Buffer.from(str, "base64"))

--- a/packages/platform-node/src/internal/encoding/Base64Url.ts
+++ b/packages/platform-node/src/internal/encoding/Base64Url.ts
@@ -1,0 +1,23 @@
+import * as Base64 from "@effect/platform-node/internal/encoding/Base64"
+
+/** @internal */
+export const encode = (data: Uint8Array) =>
+  Base64.encode(data).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_")
+
+/** @internal */
+export const decode = (str: string) => {
+  const length = str.length
+  if (length % 4 === 1) {
+    throw new TypeError("Invalid base64url string")
+  }
+
+  if (!/^[-_A-Z0-9]*?={0,2}$/i.test(str)) {
+    throw new TypeError("Invalid base64url string")
+  }
+
+  // Some variants allow or require omitting the padding '=' signs
+  let sanitized = length % 4 === 2 ? `${str}==` : length % 4 === 3 ? `${str}=` : str
+  sanitized = sanitized.replace(/-/g, "+").replace(/_/g, "/")
+
+  return Base64.decode(sanitized)
+}

--- a/packages/platform-node/src/internal/encoding/Hex.ts
+++ b/packages/platform-node/src/internal/encoding/Hex.ts
@@ -1,0 +1,5 @@
+/** @internal */
+export const encode = (bytes: Uint8Array) => Buffer.from(bytes).toString("hex")
+
+/** @internal */
+export const decode = (str: string) => Uint8Array.from(Buffer.from(str, "hex"))

--- a/packages/platform-node/test/Encoding.test.ts
+++ b/packages/platform-node/test/Encoding.test.ts
@@ -1,0 +1,132 @@
+import * as Either from "@effect/data/Either"
+import * as Encoding from "@effect/platform-node/Encoding"
+import { describe, expect, it } from "vitest"
+
+describe.concurrent("Base64", () => {
+  const valid: Array<[string, string]> = [
+    ["", ""],
+    ["ß", "w58="],
+    ["f", "Zg=="],
+    ["fo", "Zm8="],
+    ["foo", "Zm9v"],
+    ["foob", "Zm9vYg=="],
+    ["fooba", "Zm9vYmE="],
+    ["foobar", "Zm9vYmFy"]
+  ]
+
+  const invalid: Array<string> = [
+    "ab\fcd",
+    "ab\t\n\f\r cd",
+    " \t\n\f\r ab\t\n\f\r cd\t\n\f\r ",
+    "a=b",
+    "abc=d",
+    "a",
+    "ab\t\n\f\r =\t\n\f\r =\t\n\f\r ",
+    "abcde",
+    "ab=c",
+    "=a",
+    "ab\u00a0cd",
+    "A",
+    "////A",
+    "/",
+    "AAAA/",
+    "\0nonsense",
+    "abcd\0nonsense"
+  ]
+
+  it.each(valid)(`should decode %j => %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    const decoded = Encoding.decodeBase64(encoded)
+    assert(Either.isRight(decoded))
+    expect(decoded.right).toStrictEqual(bytes)
+  })
+
+  it.each(valid)(`should encode %j <= %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    expect(Encoding.encodeBase64(bytes)).toStrictEqual(encoded)
+  })
+
+  it.each(invalid)(`should refuse to decode %j`, (encoded: string) => {
+    const decoded = Encoding.decodeBase64(encoded)
+    assert(Either.isLeft(decoded))
+    expect(decoded.left).toBeInstanceOf(Encoding.Base64DecodeError)
+  })
+})
+
+describe.concurrent("Base64Url", () => {
+  const valid: Array<[string, string]> = [
+    ["", ""],
+    ["ß", "w58"],
+    ["f", "Zg"],
+    ["fo", "Zm8"],
+    ["foo", "Zm9v"],
+    ["foob", "Zm9vYg"],
+    ["fooba", "Zm9vYmE"],
+    ["foobar", "Zm9vYmFy"],
+    [">?>d?ß", "Pj8-ZD_Dnw"]
+  ]
+
+  const invalid: Array<string> = [
+    "Pj8/ZD+Dnw",
+    "PDw/Pz8+Pg",
+    "Pj8/ZD+Dnw==",
+    "PDw/Pz8+Pg=="
+  ]
+
+  it.each(valid)(`should decode %j => %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    const decoded = Encoding.decodeBase64Url(encoded)
+    assert(Either.isRight(decoded))
+    expect(decoded.right).toStrictEqual(bytes)
+  })
+
+  it.each(valid)(`should encode %j <= %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    expect(Encoding.encodeBase64Url(bytes)).toStrictEqual(encoded)
+  })
+
+  it.each(invalid)(`should refuse to decode %j`, (encoded: string) => {
+    const decoded = Encoding.decodeBase64Url(encoded)
+    assert(Either.isLeft(decoded))
+    expect(decoded.left).toBeInstanceOf(Encoding.Base64UrlDecodeError)
+  })
+})
+
+describe.concurrent("Hex", () => {
+  const valid: Array<[string, Uint8Array]> = [
+    ["", Uint8Array.from([])],
+    ["0001020304050607", Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])],
+    ["08090a0b0c0d0e0f", Uint8Array.from([8, 9, 10, 11, 12, 13, 14, 15])],
+    ["f0f1f2f3f4f5f6f7", Uint8Array.from([0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7])],
+    ["f8f9fafbfcfdfeff", Uint8Array.from([0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff])],
+    ["67", new TextEncoder().encode("g")],
+    ["e3a1", Uint8Array.from([0xe3, 0xa1])]
+  ]
+
+  const invalid: Array<string> = [
+    "0",
+    "zd4aa",
+    "d4aaz",
+    "30313",
+    "0g",
+    "00gg",
+    "0\x01",
+    "ffeed"
+  ]
+
+  it.each(valid)(`should decode %j => %o`, (hex: string, bytes: Uint8Array) => {
+    const decoded = Encoding.decodeHex(hex)
+    assert(Either.isRight(decoded))
+    expect(decoded.right).toStrictEqual(bytes)
+  })
+
+  it.each(valid)(`should encode %j <= %o`, (hex: string, bytes: Uint8Array) => {
+    expect(Encoding.encodeHex(bytes)).toStrictEqual(hex)
+  })
+
+  it.each(invalid)(`should refuse to decode %j`, (hex: string) => {
+    const decoded = Encoding.decodeHex(hex)
+    assert(Either.isLeft(decoded), `Expected ${decoded} to be invalid`)
+    expect(decoded.left).toBeInstanceOf(Encoding.HexDecodeError)
+  })
+})

--- a/packages/platform/src/Encoding.ts
+++ b/packages/platform/src/Encoding.ts
@@ -1,0 +1,130 @@
+/**
+ * This module provides encoding & decoding functionality for:
+ *
+ * - base64 (RFC4648)
+ * - base64 (URL)
+ * - hex
+ *
+ * @since 1.0.0
+ */
+import * as Either from "@effect/data/Either"
+import * as Base64 from "@effect/platform/internal/encoding/Base64"
+import * as Base64Url from "@effect/platform/internal/encoding/Base64Url"
+import * as Hex from "@effect/platform/internal/encoding/Hex"
+
+/**
+ * Encodes a Uint8Array into a base64 (RFC4648) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const encodeBase64 = Base64.encode
+
+/**
+ * @since 1.0.0
+ */
+export class Base64DecodeError {
+  /** @since 1.0.0 */
+  readonly _tag = "Base64DecodeError"
+}
+
+/**
+ * Decodes a base64 (RFC4648) encoded string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const decodeBase64 = (str: string): Either.Either<Base64DecodeError, Uint8Array> => {
+  try {
+    return Either.right(Base64.decode(str))
+  } catch {
+    return Either.left(new Base64DecodeError())
+  }
+}
+
+/**
+ * Unsafely decodes a base64 (RFC4648) encoded string. Throws a type error if the
+ * given value isn't a valid base64 (RFC4648) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const unsafeDecodeBase64 = Base64.decode
+
+/**
+ * Encodes a Uint8Array into a base64 (URL) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const encodeBase64Url = Base64Url.encode
+
+/**
+ * @since 1.0.0
+ */
+export class Base64UrlDecodeError {
+  /** @since 1.0.0 */
+  readonly _tag = "Base64UrlDecodeError"
+}
+
+/**
+ * Decodes a base64 (URL) encoded string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const decodeBase64Url = (str: string): Either.Either<Base64UrlDecodeError, Uint8Array> => {
+  try {
+    return Either.right(Base64Url.decode(str))
+  } catch {
+    return Either.left(new Base64UrlDecodeError())
+  }
+}
+
+/**
+ * Unsafely decodes a base64 (URL) encoded string. Throws a type error if the
+ * given value isn't a valid base64 (URL) string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const unsafeDecodeBase64Url = Base64Url.decode
+
+/**
+ * Encodes a Uint8Array into a hex string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const encodeHex = Hex.encode
+
+/**
+ * @since 1.0.0
+ */
+export class HexDecodeError {
+  /** @since 1.0.0 */
+  readonly _tag = "HexDecodeError"
+}
+
+/**
+ * Decodes a hex encoded string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const decodeHex = (str: string): Either.Either<HexDecodeError, Uint8Array> => {
+  try {
+    return Either.right(Hex.decode(str))
+  } catch {
+    return Either.left(new HexDecodeError())
+  }
+}
+
+/**
+ * Unsafely decodes a hex encoded string. Throws a type error if the
+ * given value isn't a valid hex string.
+ *
+ * @category encoding
+ * @since 1.0.0
+ */
+export const unsafeDecodeHex = Hex.decode

--- a/packages/platform/src/internal/encoding/Base64.ts
+++ b/packages/platform/src/internal/encoding/Base64.ts
@@ -1,0 +1,268 @@
+/** @internal */
+export const encode = (bytes: Uint8Array) => {
+  const length = bytes.length
+
+  let result = ""
+  let i: number
+
+  for (i = 2; i < length; i += 3) {
+    result += base64abc[bytes[i - 2] >> 2]
+    result += base64abc[((bytes[i - 2] & 0x03) << 4) | (bytes[i - 1] >> 4)]
+    result += base64abc[((bytes[i - 1] & 0x0f) << 2) | (bytes[i] >> 6)]
+    result += base64abc[bytes[i] & 0x3f]
+  }
+
+  if (i === length + 1) {
+    // 1 octet yet to write
+    result += base64abc[bytes[i - 2] >> 2]
+    result += base64abc[(bytes[i - 2] & 0x03) << 4]
+    result += "=="
+  }
+
+  if (i === length) {
+    // 2 octets yet to write
+    result += base64abc[bytes[i - 2] >> 2]
+    result += base64abc[((bytes[i - 2] & 0x03) << 4) | (bytes[i - 1] >> 4)]
+    result += base64abc[(bytes[i - 1] & 0x0f) << 2]
+    result += "="
+  }
+
+  return result
+}
+
+/** @internal */
+export const decode = (str: string) => {
+  const length = str.length
+  if (length % 4 !== 0) {
+    throw new TypeError("Invalid base64 string")
+  }
+
+  const index = str.indexOf("=")
+  if (index !== -1 && ((index < length - 2) || (index === length - 2 && str[length - 1] !== "="))) {
+    throw new TypeError("Invalid base64 string")
+  }
+
+  const missingOctets = str.endsWith("==") ? 2 : str.endsWith("=") ? 1 : 0
+  const result = new Uint8Array(3 * (length / 4))
+  for (let i = 0, j = 0; i < length; i += 4, j += 3) {
+    const buffer = getBase64Code(str.charCodeAt(i)) << 18 |
+      getBase64Code(str.charCodeAt(i + 1)) << 12 |
+      getBase64Code(str.charCodeAt(i + 2)) << 6 |
+      getBase64Code(str.charCodeAt(i + 3))
+
+    result[j] = buffer >> 16
+    result[j + 1] = (buffer >> 8) & 0xff
+    result[j + 2] = buffer & 0xff
+  }
+
+  return result.subarray(0, result.length - missingOctets)
+}
+
+/** @internal */
+function getBase64Code(charCode: number) {
+  if (charCode >= base64codes.length) {
+    throw new TypeError("Invalid base64 string")
+  }
+
+  const code = base64codes[charCode]
+  if (code === 255) {
+    throw new TypeError("Invalid base64 string")
+  }
+
+  return code
+}
+
+/** @internal */
+const base64abc = [
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "I",
+  "J",
+  "K",
+  "L",
+  "M",
+  "N",
+  "O",
+  "P",
+  "Q",
+  "R",
+  "S",
+  "T",
+  "U",
+  "V",
+  "W",
+  "X",
+  "Y",
+  "Z",
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+  "i",
+  "j",
+  "k",
+  "l",
+  "m",
+  "n",
+  "o",
+  "p",
+  "q",
+  "r",
+  "s",
+  "t",
+  "u",
+  "v",
+  "w",
+  "x",
+  "y",
+  "z",
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "+",
+  "/"
+]
+
+/** @internal */
+const base64codes = [
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  62,
+  255,
+  255,
+  255,
+  63,
+  52,
+  53,
+  54,
+  55,
+  56,
+  57,
+  58,
+  59,
+  60,
+  61,
+  255,
+  255,
+  255,
+  0,
+  255,
+  255,
+  255,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  24,
+  25,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  26,
+  27,
+  28,
+  29,
+  30,
+  31,
+  32,
+  33,
+  34,
+  35,
+  36,
+  37,
+  38,
+  39,
+  40,
+  41,
+  42,
+  43,
+  44,
+  45,
+  46,
+  47,
+  48,
+  49,
+  50,
+  51
+]

--- a/packages/platform/src/internal/encoding/Base64Url.ts
+++ b/packages/platform/src/internal/encoding/Base64Url.ts
@@ -1,0 +1,23 @@
+import * as Base64 from "@effect/platform/internal/encoding/Base64"
+
+/** @internal */
+export const encode = (data: Uint8Array) =>
+  Base64.encode(data).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_")
+
+/** @internal */
+export const decode = (str: string) => {
+  const length = str.length
+  if (length % 4 === 1) {
+    throw new TypeError("Invalid base64url string")
+  }
+
+  if (!/^[-_A-Z0-9]*?={0,2}$/i.test(str)) {
+    throw new TypeError("Invalid base64url string")
+  }
+
+  // Some variants allow or require omitting the padding '=' signs
+  let sanitized = length % 4 === 2 ? `${str}==` : length % 4 === 3 ? `${str}=` : str
+  sanitized = sanitized.replace(/-/g, "+").replace(/_/g, "/")
+
+  return Base64.decode(sanitized)
+}

--- a/packages/platform/src/internal/encoding/Hex.ts
+++ b/packages/platform/src/internal/encoding/Hex.ts
@@ -1,0 +1,53 @@
+/** @internal */
+export const encode = (bytes: Uint8Array) => {
+  const length = bytes.length * 2
+  const result = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    const v = bytes[i]
+    result[i * 2] = hexTable[v >> 4]
+    result[i * 2 + 1] = hexTable[v & 0x0f]
+  }
+
+  return new TextDecoder().decode(result)
+}
+
+/** @internal */
+export const decode = (str: string) => {
+  const bytes = new TextEncoder().encode(str)
+  if (bytes.length % 2 !== 0) {
+    throw new TypeError("Invalid hex string")
+  }
+
+  const length = bytes.length / 2
+  const result = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    const a = fromHexChar(bytes[i * 2])
+    const b = fromHexChar(bytes[i * 2 + 1])
+    result[i] = (a << 4) | b
+  }
+
+  return result
+}
+
+/** @internal */
+const hexTable = Uint8Array.from([48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102])
+
+/** @internal */
+const fromHexChar = (byte: number) => {
+  // '0' <= byte && byte <= '9'
+  if (48 <= byte && byte <= 57) {
+    return byte - 48
+  }
+
+  // 'a' <= byte && byte <= 'f'
+  if (97 <= byte && byte <= 102) {
+    return byte - 97 + 10
+  }
+
+  // 'A' <= byte && byte <= 'F'
+  if (65 <= byte && byte <= 70) {
+    return byte - 65 + 10
+  }
+
+  throw new TypeError("Invalid hex string")
+}

--- a/packages/platform/test/Encoding.test.ts
+++ b/packages/platform/test/Encoding.test.ts
@@ -1,0 +1,132 @@
+import * as Either from "@effect/data/Either"
+import * as Encoding from "@effect/platform/Encoding"
+import { describe, expect, it } from "vitest"
+
+describe.concurrent("Base64", () => {
+  const valid: Array<[string, string]> = [
+    ["", ""],
+    ["ß", "w58="],
+    ["f", "Zg=="],
+    ["fo", "Zm8="],
+    ["foo", "Zm9v"],
+    ["foob", "Zm9vYg=="],
+    ["fooba", "Zm9vYmE="],
+    ["foobar", "Zm9vYmFy"]
+  ]
+
+  const invalid: Array<string> = [
+    "ab\fcd",
+    "ab\t\n\f\r cd",
+    " \t\n\f\r ab\t\n\f\r cd\t\n\f\r ",
+    "a=b",
+    "abc=d",
+    "a",
+    "ab\t\n\f\r =\t\n\f\r =\t\n\f\r ",
+    "abcde",
+    "ab=c",
+    "=a",
+    "ab\u00a0cd",
+    "A",
+    "////A",
+    "/",
+    "AAAA/",
+    "\0nonsense",
+    "abcd\0nonsense"
+  ]
+
+  it.each(valid)(`should decode %j => %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    const decoded = Encoding.decodeBase64(encoded)
+    assert(Either.isRight(decoded))
+    expect(decoded.right).toStrictEqual(bytes)
+  })
+
+  it.each(valid)(`should encode %j <= %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    expect(Encoding.encodeBase64(bytes)).toStrictEqual(encoded)
+  })
+
+  it.each(invalid)(`should refuse to decode %j`, (encoded: string) => {
+    const decoded = Encoding.decodeBase64(encoded)
+    assert(Either.isLeft(decoded))
+    expect(decoded.left).toBeInstanceOf(Encoding.Base64DecodeError)
+  })
+})
+
+describe.concurrent("Base64Url", () => {
+  const valid: Array<[string, string]> = [
+    ["", ""],
+    ["ß", "w58"],
+    ["f", "Zg"],
+    ["fo", "Zm8"],
+    ["foo", "Zm9v"],
+    ["foob", "Zm9vYg"],
+    ["fooba", "Zm9vYmE"],
+    ["foobar", "Zm9vYmFy"],
+    [">?>d?ß", "Pj8-ZD_Dnw"]
+  ]
+
+  const invalid: Array<string> = [
+    "Pj8/ZD+Dnw",
+    "PDw/Pz8+Pg",
+    "Pj8/ZD+Dnw==",
+    "PDw/Pz8+Pg=="
+  ]
+
+  it.each(valid)(`should decode %j => %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    const decoded = Encoding.decodeBase64Url(encoded)
+    assert(Either.isRight(decoded))
+    expect(decoded.right).toStrictEqual(bytes)
+  })
+
+  it.each(valid)(`should encode %j <= %j`, (raw: string, encoded: string) => {
+    const bytes = new TextEncoder().encode(raw)
+    expect(Encoding.encodeBase64Url(bytes)).toStrictEqual(encoded)
+  })
+
+  it.each(invalid)(`should refuse to decode %j`, (encoded: string) => {
+    const decoded = Encoding.decodeBase64Url(encoded)
+    assert(Either.isLeft(decoded))
+    expect(decoded.left).toBeInstanceOf(Encoding.Base64UrlDecodeError)
+  })
+})
+
+describe.concurrent("Hex", () => {
+  const valid: Array<[string, Uint8Array]> = [
+    ["", Uint8Array.from([])],
+    ["0001020304050607", Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])],
+    ["08090a0b0c0d0e0f", Uint8Array.from([8, 9, 10, 11, 12, 13, 14, 15])],
+    ["f0f1f2f3f4f5f6f7", Uint8Array.from([0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7])],
+    ["f8f9fafbfcfdfeff", Uint8Array.from([0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff])],
+    ["67", new TextEncoder().encode("g")],
+    ["e3a1", Uint8Array.from([0xe3, 0xa1])]
+  ]
+
+  const invalid: Array<string> = [
+    "0",
+    "zd4aa",
+    "d4aaz",
+    "30313",
+    "0g",
+    "00gg",
+    "0\x01",
+    "ffeed"
+  ]
+
+  it.each(valid)(`should decode %j => %o`, (hex: string, bytes: Uint8Array) => {
+    const decoded = Encoding.decodeHex(hex)
+    assert(Either.isRight(decoded))
+    expect(decoded.right).toStrictEqual(bytes)
+  })
+
+  it.each(valid)(`should encode %j <= %o`, (hex: string, bytes: Uint8Array) => {
+    expect(Encoding.encodeHex(bytes)).toStrictEqual(hex)
+  })
+
+  it.each(invalid)(`should refuse to decode %j`, (hex: string) => {
+    const decoded = Encoding.decodeHex(hex)
+    assert(Either.isLeft(decoded))
+    expect(decoded.left).toBeInstanceOf(Encoding.HexDecodeError)
+  })
+})


### PR DESCRIPTION
Moving this to effect/platform per your suggestion @tim-smart.

Original issue: https://github.com/Effect-TS/data/issues/469

---

I think moving this to `effect/platform` makes sense if we want to use native APIs where possible. However I ran into a couple issues while doing so ... The `Buffer` APIs for base64 & hex encoding are anything but strict. Instead of throwing an error in case of invalid input, they simply skip any invalid characters and whitespace and produce garbage. I'm wondering if we should even rely on the `Buffer` based APIs for that reason? I'd much prefer strict-by-default decoding than silently producing garbage.

These are imho our options:

1. Accept that different platforms will have different behavior (I don't like this)
2. Use the same loose decoding behavior also for the platform agnostic custom implementation (I don't like this)
3. Use the custom cross-platform implementation with strict behavior everywhere (no `Buffer` usage)
4. Perform regex input validation before decoding through the`Buffer` API (performance impact?)
5. Add a `strict` flag via a second `options` parameter to the shared `decode` interface that defaults to `true` 