### PR TITLE
Re-add http module

### DIFF
--- a/.changeset/grumpy-wolves-add.md
+++ b/.changeset/grumpy-wolves-add.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-browser": minor
+"@effect/platform-node": minor
+"@effect/platform-bun": minor
+"@effect/platform": minor
+---
+
+Re-added exports for http module

--- a/docs/platform-node/HttpServer.ts.md
+++ b/docs/platform-node/HttpServer.ts.md
@@ -126,7 +126,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const request: any
+export declare const request: typeof request
 ```
 
 Added in v1.0.0

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.23.0",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
-    "@effect/build-utils": "^0.3.1",
+    "@effect/build-utils": "^0.4.0",
     "@effect/docgen": "^0.3.0",
     "@effect/eslint-plugin": "^0.1.2",
     "@effect/language-service": "^0.0.21",
@@ -50,6 +50,12 @@
   "pnpm": {
     "patchedDependencies": {
       "@changesets/assemble-release-plan@5.2.4": "patches/@changesets__assemble-release-plan@5.2.4.patch"
+    },
+    "overrides": {
+      "@effect/platform": "workspace:*",
+      "@effect/platform-node": "workspace:*",
+      "@effect/platform-bun": "workspace:*",
+      "@effect/platform-browser": "workspace:*"
     }
   }
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -15,6 +15,14 @@
   "author": "Effect contributors",
   "license": "MIT",
   "sideEffects": false,
+  "effect": {
+    "generateExports": {
+      "include": [
+        "*.ts",
+        "Http/*.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -15,6 +15,14 @@
   "author": "Effect contributors",
   "license": "MIT",
   "sideEffects": false,
+  "effect": {
+    "generateExports": {
+      "include": [
+        "*.ts",
+        "Http/*.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",

--- a/packages/platform-node/docgen.json
+++ b/packages/platform-node/docgen.json
@@ -1,7 +1,6 @@
 {
   "exclude": ["src/internal/**/*.ts"],
   "parseCompilerOptions": {
-    "noEmit": true,
     "strict": true,
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],
@@ -11,7 +10,6 @@
     }
   },
   "examplesCompilerOptions": {
-    "noEmit": true,
     "strict": true,
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -18,6 +18,14 @@
   "author": "Effect contributors",
   "license": "MIT",
   "sideEffects": false,
+  "effect": {
+    "generateExports": {
+      "include": [
+        "*.ts",
+        "Http/*.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",

--- a/packages/platform-node/src/HttpServer.ts
+++ b/packages/platform-node/src/HttpServer.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-import * as request from "@effect/platform-node/Http/ServerRequest"
 import * as app from "@effect/platform/Http/App"
 import * as body from "@effect/platform/Http/Body"
 import * as headers from "@effect/platform/Http/Headers"
@@ -13,6 +12,7 @@ import * as urlParams from "@effect/platform/Http/UrlParams"
 import * as etag from "./Http/Etag.js"
 import * as formData from "./Http/FormData.js"
 import * as server from "./Http/Server.js"
+import * as request from "./Http/ServerRequest.js"
 
 export {
   /**

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -15,6 +15,14 @@
   "author": "Effect contributors",
   "license": "MIT",
   "sideEffects": false,
+  "effect": {
+    "generateExports": {
+      "include": [
+        "*.ts",
+        "Http/*.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@effect/platform': workspace:*
+  '@effect/platform-node': workspace:*
+  '@effect/platform-bun': workspace:*
+  '@effect/platform-browser': workspace:*
+
 patchedDependencies:
   '@changesets/assemble-release-plan@5.2.4':
     hash: z2vvyydifzjx5lfl7g6is67lqy
@@ -32,8 +38,8 @@ importers:
         specifier: ^2.26.2
         version: 2.26.2
       '@effect/build-utils':
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.4.0
+        version: 0.4.0
       '@effect/docgen':
         specifier: ^0.3.0
         version: 0.3.0(fast-check@3.13.2)(tsx@3.14.0)(typescript@5.2.2)
@@ -689,8 +695,8 @@ packages:
     resolution: {integrity: sha512-rPwwm/RrFIolz6xHa8Kzpshuwpe+xu/XcEw9iUmRF2tnyIwxxaW7XoFKaQ+GfPju81cKpH4vJeq7/2IizKvyjg==}
     dev: true
 
-  /@effect/build-utils@0.3.1:
-    resolution: {integrity: sha512-MoyN7zj3Y068rV08SDaOSAyoKXjOSgG2C4O1fHuDmihnti5XLNt0rpCORbPhQhIwzFp14YLYeZihp3ypDmWlQQ==}
+  /@effect/build-utils@0.4.0:
+    resolution: {integrity: sha512-1dL2qgzfGECCvMZ2BXhNjAdSDsKS9zpNJne8caxXRI8FtjFNPuj3HYOhYZVmaYfSvzwlC+p9nPBTRaiczoLe8w==}
     engines: {node: '>=16.17.1'}
     hasBin: true
     dev: true
@@ -703,7 +709,7 @@ packages:
       tsx: ^3.14.0
       typescript: ^5.2.2
     dependencies:
-      '@effect/platform-node': 0.28.3(@effect/schema@0.47.2)(effect@2.0.0-next.54)
+      '@effect/platform-node': link:packages/platform-node/dist
       '@effect/schema': 0.47.2(effect@2.0.0-next.54)(fast-check@3.13.2)
       chalk: 5.3.0
       doctrine: 3.0.0
@@ -729,32 +735,6 @@ packages:
 
   /@effect/language-service@0.0.21:
     resolution: {integrity: sha512-e8vfKbjnbYiyneBincEFS0tzXluopGK77OkVFbPRtUbNDS5tJfb+jiwOQEiqASDsadcZmd+9J9+Q6v/z7GuN2g==}
-    dev: true
-
-  /@effect/platform-node@0.28.3(@effect/schema@0.47.2)(effect@2.0.0-next.54):
-    resolution: {integrity: sha512-rh8GfCRs4BjqmQKuR06xSDJOY2rgts9+AF4fCXXau5/1Mg8MvWMkWH727fX+XCGD7mjQtMmaFpYgfBXFprFdDA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      effect: 2.0.0-next.54
-    dependencies:
-      '@effect/platform': 0.27.3(@effect/schema@0.47.2)(effect@2.0.0-next.54)
-      busboy: 1.6.0
-      effect: 2.0.0-next.54
-      mime: 3.0.0
-    transitivePeerDependencies:
-      - '@effect/schema'
-    dev: true
-
-  /@effect/platform@0.27.3(@effect/schema@0.47.2)(effect@2.0.0-next.54):
-    resolution: {integrity: sha512-CnG/Yddsy7nx224h8Gdlj8ho6Hc7qjpAF4sQDk9HqjS2kMOAOjlalWi2skpi2YcZPaNqSJ/r7yT06HvD6sHVrg==}
-    peerDependencies:
-      '@effect/schema': ^0.47.1
-      effect: 2.0.0-next.54
-    dependencies:
-      '@effect/schema': 0.47.2(effect@2.0.0-next.54)(fast-check@3.13.2)
-      effect: 2.0.0-next.54
-      find-my-way: 7.7.0
-      path-browserify: 1.0.1
     dev: true
 
   /@effect/schema@0.47.2(effect@2.0.0-next.54)(fast-check@3.13.2):
@@ -1880,6 +1860,7 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
+    dev: false
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2922,6 +2903,7 @@ packages:
 
   /fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+    dev: false
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2960,6 +2942,7 @@ packages:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
     dependencies:
       fast-decode-uri-component: 1.0.1
+    dev: false
 
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -3022,6 +3005,7 @@ packages:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 2.0.0
+    dev: false
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -4139,6 +4123,7 @@ packages:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
+    dev: false
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -4944,6 +4929,7 @@ packages:
   /ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
+    dev: false
 
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -5001,6 +4987,7 @@ packages:
     resolution: {integrity: sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==}
     dependencies:
       ret: 0.2.2
+    dev: false
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -5216,6 +5203,7 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}


### PR DESCRIPTION
@tim-smart So the interesting thing here is that `docgen` depends on `platform`. Now, yesterday Giulio updated `docgen` and also bumped the version of `platform` in it. However, that version was broken (missing the `Http` exports).

Now, if we do not override the `@effect/platform` deps in the entire working tree with the workspace versions `docgen` will breaks when trying to resolve the `@effect/platform/Http/*` entrypoints while parsing the documentation of the package.

This seems like there's a problem in how docgen resolves packages because it should really resolve them from the package it is scanning and not from itself. Anyways ... This fixes it. But it might break in the future if there are breaking changes in `platform` and `docgen` hasn't been updated with those yet because now we force `docgen` to use our workspace modules.