### PR TITLE
fix: added missing File type export

### DIFF
--- a/.changeset/old-books-pump.md
+++ b/.changeset/old-books-pump.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+---
+
+fix: added missing File type export

--- a/docs/platform-bun/FileSystem.ts.md
+++ b/docs/platform-bun/FileSystem.ts.md
@@ -17,6 +17,7 @@ Added in v1.0.0
 - [layer](#layer)
   - [layer](#layer-1)
 - [model](#model)
+  - [File](#file)
   - [MakeDirectoryOptions](#makedirectoryoptions)
   - [MakeTempDirectoryOptions](#maketempdirectoryoptions)
   - [MakeTempFileOptions](#maketempfileoptions)
@@ -57,6 +58,16 @@ export declare const layer: Layer<never, never, FileSystem>
 Added in v1.0.0
 
 # model
+
+## File
+
+**Signature**
+
+```ts
+export declare const File: File
+```
+
+Added in v1.0.0
 
 ## MakeDirectoryOptions
 

--- a/docs/platform-node/FileSystem.ts.md
+++ b/docs/platform-node/FileSystem.ts.md
@@ -17,6 +17,7 @@ Added in v1.0.0
 - [layer](#layer)
   - [layer](#layer-1)
 - [model](#model)
+  - [File](#file)
   - [MakeDirectoryOptions](#makedirectoryoptions)
   - [MakeTempDirectoryOptions](#maketempdirectoryoptions)
   - [MakeTempFileOptions](#maketempfileoptions)
@@ -57,6 +58,16 @@ export declare const layer: Layer<never, never, FileSystem>
 Added in v1.0.0
 
 # model
+
+## File
+
+**Signature**
+
+```ts
+export declare const File: File
+```
+
+Added in v1.0.0
 
 ## MakeDirectoryOptions
 

--- a/packages/platform-bun/src/FileSystem.ts
+++ b/packages/platform-bun/src/FileSystem.ts
@@ -7,6 +7,11 @@ export type {
    * @since 1.0.0
    * @category model
    */
+  File,
+  /**
+   * @since 1.0.0
+   * @category model
+   */
   MakeDirectoryOptions,
   /**
    * @since 1.0.0

--- a/packages/platform-node/src/FileSystem.ts
+++ b/packages/platform-node/src/FileSystem.ts
@@ -11,6 +11,11 @@ export type {
    * @since 1.0.0
    * @category model
    */
+  File,
+  /**
+   * @since 1.0.0
+   * @category model
+   */
   MakeDirectoryOptions,
   /**
    * @since 1.0.0


### PR DESCRIPTION
I noticed that the File type wasn't being exported when using platform-bun or platform-node. I'm not sure if this is on purpose or not but I found myself trying to import it from /platform-bun, being disappointed, and having to import it from /platform instead. lol