### PR TITLE
[platform-node] expose http NodeClient fromAgent

### DIFF
--- a/.changeset/light-mirrors-type.md
+++ b/.changeset/light-mirrors-type.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Export http NodeClient fromAgent method

--- a/docs/platform-node/Http/NodeClient.ts.md
+++ b/docs/platform-node/Http/NodeClient.ts.md
@@ -18,6 +18,7 @@ Added in v1.0.0
   - [HttpAgentTypeId](#httpagenttypeid)
   - [HttpAgentTypeId (type alias)](#httpagenttypeid-type-alias)
   - [agentLayer](#agentlayer)
+  - [fromAgent](#fromagent)
   - [makeAgent](#makeagent)
   - [makeAgentLayer](#makeagentlayer)
 - [constructors](#constructors)
@@ -80,6 +81,16 @@ Added in v1.0.0
 
 ```ts
 export declare const agentLayer: Layer.Layer<never, never, HttpAgent>
+```
+
+Added in v1.0.0
+
+## fromAgent
+
+**Signature**
+
+```ts
+export declare const fromAgent: (agent: HttpAgent) => Client.Client.Default
 ```
 
 Added in v1.0.0

--- a/packages/platform-node/src/Http/NodeClient.ts
+++ b/packages/platform-node/src/Http/NodeClient.ts
@@ -60,6 +60,13 @@ export const makeAgentLayer: (options?: Https.AgentOptions) => Layer.Layer<never
 
 /**
  * @since 1.0.0
+ * @category agent
+ */
+export const fromAgent: (agent: HttpAgent) => Client.Client.Default =
+  internal.fromAgent
+
+/**
+ * @since 1.0.0
  * @category constructors
  */
 export const make: Effect.Effect<HttpAgent, never, Client.Client.Default> = internal.make

--- a/packages/platform-node/src/Http/NodeClient.ts
+++ b/packages/platform-node/src/Http/NodeClient.ts
@@ -62,8 +62,7 @@ export const makeAgentLayer: (options?: Https.AgentOptions) => Layer.Layer<never
  * @since 1.0.0
  * @category agent
  */
-export const fromAgent: (agent: HttpAgent) => Client.Client.Default =
-  internal.fromAgent
+export const fromAgent: (agent: HttpAgent) => Client.Client.Default = internal.fromAgent
 
 /**
  * @since 1.0.0

--- a/packages/platform-node/src/internal/http/nodeClient.ts
+++ b/packages/platform-node/src/internal/http/nodeClient.ts
@@ -53,7 +53,8 @@ export const makeAgentLayer = (options?: Https.AgentOptions): Layer.Layer<never,
 /** @internal */
 export const agentLayer = makeAgentLayer()
 
-const fromAgent = (agent: NodeClient.HttpAgent): Client.Client.Default =>
+/** @internal */
+export const fromAgent = (agent: NodeClient.HttpAgent): Client.Client.Default =>
   Client.makeDefault((request) =>
     Effect.flatMap(
       UrlParams.makeUrl(request.url, request.urlParams, (_) =>


### PR DESCRIPTION
I would like to be able to create an http client with custom agents, how do y'all feel about exposing the `fromAgent` helper?