### PR TITLE
Platform-node http client add error event listener in waitForResponse to handle ECONNRESET socket errors

### DIFF
--- a/.changeset/popular-avocados-attack.md
+++ b/.changeset/popular-avocados-attack.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+HttpClient added another error event listener in waitForResponse

--- a/packages/platform-node/src/internal/http/nodeClient.ts
+++ b/packages/platform-node/src/internal/http/nodeClient.ts
@@ -142,7 +142,7 @@ const sendBody = (
   })
 
 const waitForResponse = (nodeRequest: Http.ClientRequest, request: ClientRequest.ClientRequest) =>
-  Effect.async<never, never, Http.IncomingMessage>((resume) => {
+  Effect.async<never, Error.RequestError, Http.IncomingMessage>((resume) => {
     nodeRequest.on("error", (error) => {
       resume(Effect.fail(Error.RequestError({
         request,
@@ -150,11 +150,11 @@ const waitForResponse = (nodeRequest: Http.ClientRequest, request: ClientRequest
         error
       })))
     })
-    
+
     nodeRequest.on("response", (response) => {
       resume(Effect.succeed(response))
     })
-    
+
     return Effect.sync(() => {
       nodeRequest.removeAllListeners("error")
       nodeRequest.removeAllListeners("response")

--- a/packages/platform-node/src/internal/http/nodeClient.ts
+++ b/packages/platform-node/src/internal/http/nodeClient.ts
@@ -156,6 +156,7 @@ const waitForResponse = (nodeRequest: Http.ClientRequest, request: ClientRequest
     })
     
     return Effect.sync(() => {
+      nodeRequest.removeAllListeners("error")
       nodeRequest.removeAllListeners("response")
     })
   })


### PR DESCRIPTION
fixes #328 