### PR TITLE
Node HttpClient treat just upgrade response as successful response

### DIFF
--- a/.changeset/calm-turkeys-shop.md
+++ b/.changeset/calm-turkeys-shop.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Http client treats upgrade response as successful response

--- a/packages/platform-node/src/internal/http/nodeClient.ts
+++ b/packages/platform-node/src/internal/http/nodeClient.ts
@@ -156,10 +156,12 @@ const waitForResponse = (nodeRequest: Http.ClientRequest, request: ClientRequest
       nodeRequest.off("error", onError)
       resume(Effect.succeed(response))
     }
+    nodeRequest.on("upgrade", onResponse)
     nodeRequest.on("response", onResponse)
 
     return Effect.sync(() => {
       nodeRequest.off("error", onError)
+      nodeRequest.off("upgrade", onResponse)
       nodeRequest.off("response", onResponse)
     })
   })


### PR DESCRIPTION
I didn't make a reproducible example for this but I have a request the responds immediately with an "connection: upgrade" response and never sends anything in the body - it just upgrades the connection right away and then waits for your to send more data over the tcp socket. This results in the NodeCient request hanging forever because the server never responds with any data, just an upgrade request.

I have modified the `waitForResponse` handler so that it resumes if the server sends a response or a "connection: upgrade" (Because the node.js event emitter does not emit a response event for a "connection: upgrade" response)

Let me know if you think this is an adequate way to handle this case, or if you think of something else, or if you think the NodeClient shouldn't handle this at all and I should maybe wait for the websockets pr to see if that implements something I could use.